### PR TITLE
Git root finding + python compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,20 @@ else()
 	endif()
 endif()
 
+# find out current git root
+execute_process(COMMAND git rev-parse --show-toplevel
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE GCF_GIT_ROOT
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT GCF_GIT_ROOT)
+  message(WARNING "Not in a git repository")
+else()
+  message(STATUS "Found git root: ${GCF_GIT_ROOT}")
+endif()
+
+
 if("${GCF_PYTHON_PATH}" STREQUAL "NOTSET")
-	find_program(FIND_PYTHON python)
+	find_program(FIND_PYTHON python2)
 	if("${FIND_PYTHON}" STREQUAL "FIND_PYTHON-NOTFOUND")
 		message(FATAL_ERROR
 		   	"Could not find 'python' please set GCF_PYTHON_PATH:STRING")
@@ -68,7 +80,7 @@ string(REGEX REPLACE "\\\\" "/" GCF_CLANGFORMAT_PATH ${GCF_CLANGFORMAT_PATH})
 
 configure_file(
 	${CMAKE_CURRENT_SOURCE_DIR}/git-pre-commit-hook
-	${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)
+  ${GCF_GIT_ROOT}/.git/hooks/pre-commit)
 
 add_custom_target(format ALL
 	${GCF_SCRIPT} --cmake ${GCF_GIT_PATH} ${GCF_CLANGFORMAT_PATH} -style=${GCF_CLANGFORMAT_STYLE}

--- a/git-cmake-format.py
+++ b/git-cmake-format.py
@@ -34,11 +34,7 @@ def getEditedFiles(InPlace):
     DiffIndex = subprocess.Popen(GitArgs, stdout=subprocess.PIPE)
     DiffIndexRet = DiffIndex.stdout.read().strip()
 
-    files = DiffIndexRet.split('\n')
-    root = getGitRoot()
-
-    return [os.path.join(root, x) for x in files]
-
+    return DiffIndexRet.split('\n')
 
 def isFormattable(File):
     Extension = os.path.splitext(File)[1]
@@ -48,8 +44,8 @@ def isFormattable(File):
     return False
 
 
-def formatFile(FileName):
-    subprocess.Popen([ClangFormat, Style, '-i', FileName])
+def formatFile(FileName, GitRoot):
+    subprocess.Popen([ClangFormat, Style, '-i', os.path.join(GitRoot,FileName)])
     return
 
 
@@ -101,9 +97,10 @@ if __name__ == "__main__":
     ReturnCode = 0
 
     if InPlace:
+        GitRoot = getGitRoot()
         for FileName in EditedFiles:
             if isFormattable(FileName):
-                formatFile(FileName)
+                formatFile(FileName,GitRoot)
         sys.exit(ReturnCode)
 
     for FileName in EditedFiles:

--- a/git-cmake-format.py
+++ b/git-cmake-format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 
 import os
@@ -20,6 +20,10 @@ def getGitHead():
     else:
         return 'HEAD'
 
+def getGitRoot():
+    RevParse = subprocess.Popen([Git, 'rev-parse', '--show-toplevel'],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return RevParse.stdout.read().strip()
 
 def getEditedFiles(InPlace):
     Head = getGitHead()
@@ -28,8 +32,12 @@ def getEditedFiles(InPlace):
         GitArgs.append('--cached')
     GitArgs.extend(['--diff-filter=ACMR', '--name-only', Head])
     DiffIndex = subprocess.Popen(GitArgs, stdout=subprocess.PIPE)
-    DiffIndexRet = DiffIndex.stdout.read()
-    return DiffIndexRet.split('\n')
+    DiffIndexRet = DiffIndex.stdout.read().strip()
+
+    files = DiffIndexRet.split('\n')
+    root = getGitRoot()
+
+    return [os.path.join(root, x) for x in files]
 
 
 def isFormattable(File):


### PR DESCRIPTION
Both the CMake script and the python script find out the git root directory per git rev-parse call to adapt to various repository layouts
To make the scripts usable on systems with /usr/bin/python linking to python3, explicityly require python2 in the shebang and CMake find_program call