### PR TITLE
Use find_package(...) to locate clang-format, git, and python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,22 +18,20 @@ execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --show-toplevel
   OUTPUT_VARIABLE GCF_GIT_ROOT
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(NOT GCF_GIT_ROOT)
-  message(SEND_ERROR "Not in a git repository")
+  message(WARNING "Not in a git repository")
 else()
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/git-pre-commit-hook
     ${GCF_GIT_ROOT}/.git/hooks/pre-commit
-    @ONLY
-  )
+    @ONLY)
   unset(GCF_GIT_ROOT)
 
   add_custom_target(format
     ${PYTHON_EXECUTABLE} ${GCF_SCRIPT}
     --cmake ${GIT_EXECUTABLE}
     ${CLANG_FORMAT_EXECUTABLE} -style=${GCF_CLANGFORMAT_STYLE} -ignore=${GCF_IGNORE_LIST}
-	  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  )
+	  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   unset(GCF_SCRIPT)
 else()
-  message(SEND_ERROR "Cannot locate top .git repository")
+  message(WARNING "Cannot locate top .git repository")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,80 +1,39 @@
 project(git-clang-format-cmake)
 cmake_minimum_required(VERSION 2.8)
 
-set(GCF_GIT_PATH "NOTSET" CACHE STRING "Absolute path to the git executable")
-set(GCF_PYTHON_NAME "python" CACHE STRING "Name of the python executable, eg. python2")
-set(GCF_PYTHON_PATH "NOTSET" CACHE STRING "Absolute path to the python executable")
-set(GCF_CLANGFORMAT_PATH "NOTSET" CACHE STRING "Absolute path to the clang-format executable")
-set(GCF_CLANGFORMAT_STYLE "file" CACHE STRING "Paremter pass to clang-format -style=<here>")
-set(GCF_IGNORE_LIST "" CACHE STRING "Semi colon separeted list of directories to ignore")
+find_package(Git REQUIRED)
+find_package(PythonInterp REQUIRED)
 
-if("${GCF_GIT_PATH}" STREQUAL "NOTSET")
-	find_program(FIND_GIT git)
-	if("${FIND_GIT}" STREQUAL "FIND_GIT-NOTFOUND")
-		message(FATAL_ERROR "Could not find 'git' please set GCF_GIT_PATH:STRING")
-	else()
-		set(GCF_GIT_PATH ${FIND_GIT})
-		message(STATUS "Found: ${GCF_GIT_PATH}")
-	endif()
-else()
-	if(NOT EXISTS ${GCF_GIT_PATH})
-		message(WARNING "Could not find git: ${GCF_GIT_PATH}")
-	else()
-		message(STATUS "Found: ${GCF_GIT_PATH}")
-	endif()
-endif()
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
+find_package(ClangFormat REQUIRED)
 
-if("${GCF_PYTHON_PATH}" STREQUAL "NOTSET")
-	find_program(FIND_PYTHON ${GCF_PYTHON_NAME})
-	if("${FIND_PYTHON}" STREQUAL "FIND_PYTHON-NOTFOUND")
-		message(FATAL_ERROR "Could not find '${GCF_PYTHON_NAME}' please set GCF_PYTHON_PATH:STRING")
-	else()
-		set(GCF_PYTHON_PATH ${FIND_PYTHON})
-		message(STATUS "Found: ${GCF_PYTHON_PATH}")
-	endif()
-else()
-	if(NOT EXISTS ${GCF_PYTHON_PATH})
-		message(WARNING "Could not find python: ${GCF_PYTHON_PATH}")
-	else()
-		message(STATUS "Found: ${GCF_PYTHON_PATH}")
-	endif()
-endif()
-
-if("${GCF_CLANGFORMAT_PATH}" STREQUAL "NOTSET")
-	find_program(FIND_CLANGFORMAT clang-format)
-	if("${FIND_CLANGFORMAT}" STREQUAL "FIND_CLANGFORMAT-NOTFOUND")
-		message(FATAL_ERROR "Could not find 'clang-format' please set GCF_CLANGFORMAT_PATH:STRING")
-	else()
-		set(GCF_CLANGFORMAT_PATH ${FIND_CLANGFORMAT})
-		message(STATUS "Found: ${GCF_CLANGFORMAT_PATH}")
-	endif()
-else()
-	if(NOT EXISTS ${GCF_CLANGFORMAT_PATH})
-		message(WARNING "Could not find clang-format: ${GCF_CLANGFORMAT_PATH}")
-	else()
-		message(STATUS "Found: ${GCF_CLANGFORMAT_PATH}")
-	endif()
-endif()
-
+set(GCF_CLANGFORMAT_STYLE "file" CACHE STRING
+	"Parameter pass to clang-format -style=<here>")
+set(GCF_IGNORE_LIST "" CACHE STRING
+	"Semi colon separated list of directories to ignore")
 set(GCF_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/git-cmake-format.py)
-string(REGEX REPLACE "\\\\" "/" GCF_GIT_PATH ${GCF_GIT_PATH})
-string(REGEX REPLACE "\\\\" "/" GCF_PYTHON_PATH ${GCF_PYTHON_PATH})
-string(REGEX REPLACE "\\\\" "/" GCF_CLANGFORMAT_PATH ${GCF_CLANGFORMAT_PATH})
 
-execute_process(COMMAND git rev-parse --show-toplevel
+execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --show-toplevel
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE GCF_GIT_ROOT
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(NOT GCF_GIT_ROOT)
-  message(WARNING "Not in a git repository")
+  message(SEND_ERROR "Not in a git repository")
 else()
-  message(STATUS "Found git root: ${GCF_GIT_ROOT}")
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/git-pre-commit-hook
+    ${GCF_GIT_ROOT}/.git/hooks/pre-commit
+    @ONLY
+  )
+  unset(GCF_GIT_ROOT)
+
+  add_custom_target(format
+    ${PYTHON_EXECUTABLE} ${GCF_SCRIPT}
+    --cmake ${GIT_EXECUTABLE}
+    ${CLANG_FORMAT_EXECUTABLE} -style=${GCF_CLANGFORMAT_STYLE} -ignore=${GCF_IGNORE_LIST}
+	  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
+  unset(GCF_SCRIPT)
+else()
+  message(SEND_ERROR "Cannot locate top .git repository")
 endif()
-
-configure_file(
-	${CMAKE_CURRENT_SOURCE_DIR}/git-pre-commit-hook
-  ${GCF_GIT_ROOT}/.git/hooks/pre-commit)
-
-add_custom_target(format ALL
-	${GCF_PYTHON_PATH} ${GCF_SCRIPT} --cmake ${GCF_GIT_PATH} ${GCF_CLANGFORMAT_PATH} -style=${GCF_CLANGFORMAT_STYLE} -ignore=${GCF_IGNORE_LIST}
-	WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/FindClangFormat.cmake
+++ b/FindClangFormat.cmake
@@ -1,0 +1,30 @@
+#
+#.rst:
+# FindClangFormat
+# ---------------
+#
+# The module defines the following variables
+#
+# ``CLANG_FORMAT_EXECUTABLE``
+#   Path to clang-format executable
+# ``CLANG_FORMAT_FOUND``
+#   True if the clang-format executable was found.
+#
+# Example usage:
+#
+# .. code-block:: cmake
+#
+#    find_package(ClangFormat)
+#    if(CLANG_FORMAT_FOUND)
+#      message("clang-format executable found: ${CLANG_FORMAT_EXECUTABLE}")
+#    endif()
+
+find_program(CLANG_FORMAT_EXECUTABLE
+  NAMES clang-format clang-format-3.9 clang-format-3.8
+  DOC "clang-format executable"
+)
+mark_as_advanced(CLANG_FORMAT_EXECUTABLE)
+
+if(CLANG_FORMAT_EXECUTABLE)
+  set(CLANG_FORMAT_FOUND true)
+endif()

--- a/FindClangFormat.cmake
+++ b/FindClangFormat.cmake
@@ -9,6 +9,16 @@
 #   Path to clang-format executable
 # ``CLANG_FORMAT_FOUND``
 #   True if the clang-format executable was found.
+# ``CLANG_FORMAT_VERSION``
+#   The version of clang-format found
+# ``CLANG_FORMAT_VERSION_MAJOR``
+#   The clang-format major version if specified, 0 otherwise
+# ``CLANG_FORMAT_VERSION_MINOR``
+#   The clang-format minor version if specified, 0 otherwise
+# ``CLANG_FORMAT_VERSION_PATCH``
+#   The clang-format patch version if specified, 0 otherwise
+# ``CLANG_FORMAT_VERSION_COUNT``
+#   Number of version components reported by clang-format
 #
 # Example usage:
 #
@@ -16,15 +26,58 @@
 #
 #    find_package(ClangFormat)
 #    if(CLANG_FORMAT_FOUND)
-#      message("clang-format executable found: ${CLANG_FORMAT_EXECUTABLE}")
+#      message("clang-format executable found: ${CLANG_FORMAT_EXECUTABLE}\n"
+#              "version: ${CLANG_FORMAT_VERSION}")
 #    endif()
 
 find_program(CLANG_FORMAT_EXECUTABLE
-  NAMES clang-format clang-format-3.9 clang-format-3.8
+  NAMES clang-format clang-format-5.0
+        clang-format-4.0 clang-format-3.9
+        clang-format-3.8 clang-format-3.7
+        clang-format-3.6 clang-format-3.5
+        clang-format-3.4 clang-format-3.3
   DOC "clang-format executable"
 )
 mark_as_advanced(CLANG_FORMAT_EXECUTABLE)
 
+# Extract version from command "clang-format -version"
 if(CLANG_FORMAT_EXECUTABLE)
-  set(CLANG_FORMAT_FOUND true)
+  execute_process(COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
+                  OUTPUT_VARIABLE clang_format_version
+                  ERROR_QUIET
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if (clang_format_version MATCHES "^clang-format version .*")
+    # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1 (tags/RELEASE_391/rc2)"
+    string(REGEX REPLACE
+           "clang-format version ([.0-9]+).*" "\\1"
+           CLANG_FORMAT_VERSION "${clang_format_version}")
+    # CLANG_FORMAT_VERSION sample: "3.9.1"
+
+    # Extract version components
+    string(REPLACE "." ";" clang_format_version "${CLANG_FORMAT_VERSION}")
+    list(LENGTH clang_format_version CLANG_FORMAT_VERSION_COUNT)
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 0)
+      list(GET clang_format_version 0 CLANG_FORMAT_VERSION_MAJOR)
+    else()
+      set(CLANG_FORMAT_VERSION_MAJOR 0)
+    endif()
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 1)
+      list(GET clang_format_version 1 CLANG_FORMAT_VERSION_MINOR)
+    else()
+      set(CLANG_FORMAT_VERSION_MINOR 0)
+    endif()
+    if(CLANG_FORMAT_VERSION_COUNT GREATER 2)
+      list(GET clang_format_version 2 CLANG_FORMAT_VERSION_PATCH)
+    else()
+      set(CLANG_FORMAT_VERSION_PATCH 0)
+    endif()
+  endif()
+  unset(clang_format_version)
+endif()
+
+if(CLANG_FORMAT_EXECUTABLE)
+  set(CLANG_FORMAT_FOUND TRUE)
+else()
+  set(CLANG_FORMAT_FOUND FALSE)
 endif()


### PR DESCRIPTION
* Use standard FindGit.cmake and FindPythonInterp.cmake
* Locate clang-format executable with `find_package` command
* Unset all non-cache v ariables when not required anymore
* Tag cache variables as "advanced"