### PR TITLE
Fix duplicate else() block in CMakeLists, and runtime error when using Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,9 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 find_package(ClangFormat REQUIRED)
 
 set(GCF_CLANGFORMAT_STYLE "file" CACHE STRING
-	"Parameter pass to clang-format -style=<here>")
+    "Parameter pass to clang-format -style=<here>")
 set(GCF_IGNORE_LIST "" CACHE STRING
-	"Semi colon separated list of directories to ignore")
+    "Semi colon separated list of directories to ignore")
 set(GCF_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/git-cmake-format.py)
 
 execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --show-toplevel
@@ -29,9 +29,8 @@ else()
   add_custom_target(format
     ${PYTHON_EXECUTABLE} ${GCF_SCRIPT}
     --cmake ${GIT_EXECUTABLE}
-    ${CLANG_FORMAT_EXECUTABLE} -style=${GCF_CLANGFORMAT_STYLE} -ignore=${GCF_IGNORE_LIST}
-	  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+    ${CLANG_FORMAT_EXECUTABLE} -style=${GCF_CLANGFORMAT_STYLE}
+    -ignore=${GCF_IGNORE_LIST}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   unset(GCF_SCRIPT)
-else()
-  message(WARNING "Cannot locate top .git repository")
 endif()

--- a/git-cmake-format.py
+++ b/git-cmake-format.py
@@ -24,7 +24,7 @@ def getGitHead():
 def getGitRoot():
     RevParse = subprocess.Popen([Git, 'rev-parse', '--show-toplevel'],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    return RevParse.stdout.read().strip()
+    return RevParse.stdout.read().decode().strip()
 
 def getEditedFiles(InPlace):
     Head = getGitHead()


### PR DESCRIPTION
Just a small fix of the duplicate else() statement in CMakeLists.txt which crashes the configure phase,
and a runtime error due to string vs bytes inconsistency in Python 3.